### PR TITLE
Script Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ LICENSE GNU General Public License v3.0
 
 # Description: 
 A script that extracts DBKey and decrypts all SQLITE3 database files (including db and write-ahead-logfiles ). 
-On completion a ZIP file containing all WhatsApp  decrypted LocalState db's and a SHA512 is calculated.
+On completion a ZIP file containing all WhatsApp decrypted LocalState db's and a MD5 is calculated.
 Some information also in: https://medium.com/@alberto.magno/whatsapp-desktop-and-web-live-forensics-4n6-233f640e9fb3
 
 Technique based on reverse-engineering-fu (yes! you do not need to use SQLite3 SEE to decrypt) and some info contained in following paper:
@@ -31,7 +31,7 @@ https://doi.org/10.1016/j.fsidi.2024.301861.
 - It generates the userKey to generate the dbKey for decrypting the files.
 - DbKey is used to decrypt DB and WAL files.
 - All decrypted files and the other content of LocalState are zipped.
-- SHA512 HASH file is generates for chain-of-custody purposes.
+- MD5 HASH file is generates for chain-of-custody purposes.
 
 This script uses Bouncy Castle (BC) for C# .NET (MIT License).
 https://www.bouncycastle.org/


### PR DESCRIPTION
First off, great work on this PowerShell implementation of the research paper analysis and your own reverse engineeering.
I had recently been doing analysis and research on WhatsApp as well, and hadn't quite made the progress you did. I am working on a Python implementation of the same practice as well, but I thought I would contribute to your script with the research I uncovered.

In this PR, I've added a File-Signature function, as I've uncovered what appears to be a standardized set of signatures throughout the NS16 and NS18 databases. While my testing has only been on 6 separate instances of WhatsApp installations, they all ended up providing the same results and identifiable signatures. I've implemented the signatures for the keys into the File-Signature function, and have added the details I've found in the comment string at the top of the script.

This PR will:
- Add a File Signature search (file signatures identified through research over multiple WA instances)
- Add a Windows compiled binary to search for the ODUID for testing purposes (based on the original research)
- Adds a Start-Zapixdesk function and parameters which will allow for customizable online/offline options and specific source file paths
- Removes a couple of, but not all, unused functions to centralize all key extractions processes though a single function (Get-Key)
- Switch to MD5 for checksum, as SHA512 can be computationally expensive on a live system taking 1m21 for an 8GB zip, where MD5 takes only 16 seconds.
- Fixes the Admin PowerShell execution
- Adds a pop-up dialog box at the end to indicate completion. Also allows the user to review the contents of the output and ensure script did not exit due to error
- Adds -OutputPath to allow the user to choose the location to save the generated files instead of assuming current directory. However, the default, if -OutputPath is not chosen, will be the directory from which the script is run.